### PR TITLE
Clarify ESPN cookie storage guidance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM public.ecr.aws/docker/library/python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+WORKDIR /app
+
+COPY . /app
+
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir . \
+    && pip install --no-cache-dir mcp open-webui-mcp
+
+COPY deploy/app-runner/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+EXPOSE 8000
+ENV PORT=8000
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -49,7 +49,18 @@ python -m espn_api.mcp_server
 ```
 
 Each tool invocation should include the relevant credentials, keeping your ESPN
-cookies out of the long-lived server process.
+cookies out of the long-lived server process.  When the backend is deployed as a
+service you can also set `ESPN_MCP_SWID` and `ESPN_MCP_ESPN_S2` environment
+variables; the server uses them as defaults whenever a tool invocation omits the
+cookies.  Prefer storing the cookies on the backend (for example via App Runner
+environment variables or AWS Secrets Manager references).  Frontend build-time
+environment variables are bundled into the static site and are therefore visible
+to anyone who can load the app, so they are not suitable for protecting the
+private ESPN tokens.
+
+Need a managed deployment?  Follow the
+[AWS App Runner guide](docs/aws-app-runner-backend.md) to package the MCP server
+with OpenWebUI's MCPO proxy and host it as a backend service.
 
 ### Run Tests
 ```

--- a/deploy/app-runner/entrypoint.sh
+++ b/deploy/app-runner/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+set -euo pipefail
+
+HOST="${MCPO_PROXY_HOST:-0.0.0.0}"
+PORT="${PORT:-8000}"
+
+if [ -n "${MCPO_PROXY_COMMAND:-}" ]; then
+    exec sh -c "${MCPO_PROXY_COMMAND}"
+fi
+
+MCP_SERVER_COMMAND="${MCP_SERVER_COMMAND:-python -m espn_api.mcp_server}"
+
+exec mcpo-proxy serve \
+    --host "${HOST}" \
+    --port "${PORT}" \
+    --command "${MCP_SERVER_COMMAND}"
+

--- a/docs/aws-app-runner-backend.md
+++ b/docs/aws-app-runner-backend.md
@@ -1,0 +1,178 @@
+# Deploying the ESPN Fantasy MCP backend to AWS App Runner
+
+This guide packages the `espn_api` MCP server together with the [OpenWebUI MCPO
+proxy](https://docs.openwebui.com/openapi-servers/mcp) and deploys it on
+[AWS App Runner](https://aws.amazon.com/apprunner/).  App Runner keeps the
+container running, provides an HTTPS endpoint, and automatically redeploys the
+service when you push a new image tag.
+
+> **Tip:** The instructions below assume you already deployed the frontend with
+> AWS Amplify.  Once App Runner exposes the backend URL you can point the
+> frontend to it by setting the `VITE_BASE_URL` environment variable (see
+> [section 5](#5-share-the-backend-url-with-the-frontend)).
+
+## 1. Prerequisites
+
+* An AWS account with permissions for Elastic Container Registry (ECR) and App
+  Runner.
+* AWS CLI v2 configured locally (`aws configure`).
+* Docker installed locally so you can build and push the container image.
+* Access to an ESPN league plus the `SWID`/`espn_s2` cookies that the MCP tools
+  require.
+* (Optional) A custom domain managed in Route 53 if you plan to add one later.
+
+## 2. Package the backend
+
+The repository now contains a production `Dockerfile` and entrypoint that start
+OpenWebUI's MCPO proxy and point it at the ESPN MCP server.  Build the image
+from the repository root:
+
+```bash
+docker build -t espn-mcp-backend .
+```
+
+The Docker image:
+
+* Installs the package together with the optional `mcp` extra and the
+  `open-webui-mcp` proxy runtime.
+* Runs `mcpo-proxy serve` with defaults that bind to `0.0.0.0:${PORT}` (App
+  Runner injects `PORT` at runtime) and spawns `python -m espn_api.mcp_server`
+  behind the proxy.
+* Lets you override the behaviour with environment variables:
+  * `MCPO_PROXY_COMMAND` &mdash; if set, the container executes this shell command
+    verbatim.  Use it when you want full control over the proxy invocation.
+  * `MCPO_PROXY_HOST` &mdash; defaults to `0.0.0.0`.
+  * `PORT` &mdash; defaults to `8000` for local testing but is automatically
+    provided by App Runner.
+  * `MCP_SERVER_COMMAND` &mdash; defaults to `python -m espn_api.mcp_server`; point
+    it at a different MCP entrypoint if needed.
+
+You can verify everything locally by running the container and curling the
+OpenAPI description that the proxy exposes:
+
+```bash
+docker run --rm -p 8000:8000 espn-mcp-backend
+curl http://localhost:8000/openapi.json | jq '.info.title'
+```
+
+Expect a title such as `"OpenWebUI MCP Proxy"`.  You can also use the proxy's
+`/healthz` endpoint to check readiness.
+
+## 3. Push the image to Amazon ECR
+
+1. Create the repository (one time):
+   ```bash
+   aws ecr create-repository --repository-name espn-mcp-backend
+   ```
+2. Retrieve the login command and authenticate Docker:
+   ```bash
+   aws ecr get-login-password --region <region> \
+     | docker login --username AWS --password-stdin <account-id>.dkr.ecr.<region>.amazonaws.com
+   ```
+3. Tag and push the image:
+   ```bash
+   docker tag espn-mcp-backend:latest <account-id>.dkr.ecr.<region>.amazonaws.com/espn-mcp-backend:latest
+   docker push <account-id>.dkr.ecr.<region>.amazonaws.com/espn-mcp-backend:latest
+   ```
+
+## 4. Create the App Runner service
+
+1. Open the **App Runner** console and choose **Create service**.
+2. Select **Container registry** → **Amazon ECR** and pick the
+   `espn-mcp-backend` repository.
+3. Set **Deployment settings** to **Automatic** so App Runner redeploys on new
+   image pushes.
+4. Configure the service:
+   * **Service name:** `espn-mcp-backend` (or similar).
+   * **Port:** `8000` (matches the container's default `PORT`).
+   * **Auto scaling:** keep the defaults (1 concurrent request per instance).
+5. Add environment variables under **Service settings → Environment variables**:
+   * `MCP_SERVER_COMMAND` (optional) if you need to pass extra CLI flags to the
+     MCP server.  Leave unset to use the defaults.
+   * `MCPO_PROXY_COMMAND` (optional) if you prefer to provide the entire proxy
+     invocation yourself.
+   * Secrets such as league credentials so tools can call private leagues.  Set
+     `ESPN_MCP_SWID` and `ESPN_MCP_ESPN_S2` (or reference secrets with these
+     names) to provide the cookies to the backend.
+6. Attach an **Instance role** only if the backend needs AWS APIs (not required
+   for the ESPN MCP server).
+7. Review and create the service.  Initial provisioning takes a few minutes and
+   results in a default HTTPS endpoint such as
+   `https://<random>.<region>.awsapprunner.com`.
+
+## 5. Share the backend URL with the frontend
+
+Update the frontend so it targets the App Runner endpoint instead of
+`http://localhost:8000`:
+
+1. In the Amplify console open the app → **App settings → Environment
+   variables**.
+2. Add or update `VITE_BASE_URL` with the App Runner URL (or your custom
+   domain).
+3. Redeploy the Amplify app.  The frontend now proxies requests to the managed
+   backend.
+
+## 6. Secure and observe the backend
+
+* **Restrict callers** by keeping the App Runner URL private and only surfacing
+  it through the frontend.  If you need tighter controls, attach AWS WAF from
+  the App Runner console.
+* **Monitor** the built-in metrics (requests, CPU, memory, 4XX/5XX errors) from
+  the service detail page.  Configure alerts or alarms in CloudWatch if needed.
+* **Tag the service** (for example `Project=espn-mcp`) so you can track costs in
+  the AWS Cost Explorer.
+
+## 7. Optional: add a custom domain
+
+1. In the App Runner console open the service → **Custom domains** →
+   **Add domain**.
+2. Enter a hostname such as `api.example.com` and follow the prompts.  App
+   Runner provides CNAME records.
+3. Create the DNS records in Route 53 (or your DNS provider) and wait for
+   validation.
+4. Once validated, update `VITE_BASE_URL` to reference the custom domain.
+
+## 8. Wire CI/CD for future updates
+
+Automate rebuilds and deployments by pushing through GitHub Actions (or another
+CI system):
+
+* Build the Docker image.
+* Log in to ECR.
+* Push the new tag (for example `latest` or a semantic version).
+
+App Runner tracks the ECR repository; as soon as the new tag is available it
+rolls out an updated service revision.
+
+### Provide the ESPN cookies securely
+
+App Runner encrypts environment variables at rest, but it is still best
+practice to manage long-lived secrets outside of git and CI build logs.  Two
+common patterns:
+
+1. **Reference AWS Secrets Manager or Systems Manager Parameter Store.**
+   When editing the App Runner service choose **Add environment variable →
+   Reference existing secret** and pick the secret that stores the cookie value.
+   Create secrets named `ESPN_MCP_SWID` and `ESPN_MCP_ESPN_S2` so the container
+   receives the expected variables.
+2. **Inject from CI/CD.**  If a GitHub Actions workflow deploys the service, add
+   encrypted repository or organization secrets for `ESPN_MCP_SWID` and
+   `ESPN_MCP_ESPN_S2`.  Pass them to the `aws apprunner update-service` command
+   (or equivalent) using the `--environment-variables` flag.  Avoid baking the
+   cookies into the Docker image or committing them to git.
+
+With either approach the MCP server will automatically read the environment
+variables and use them as defaults whenever a client request omits the cookies.
+
+> **Why not store the cookies in the frontend?**  Amplify (and most static site
+> hosts) bake `VITE_*` variables into the generated JavaScript bundle.  Anyone
+> who loads the UI can read those values, so frontend environment variables do
+> not keep the cookies private.  Keep the ESPN tokens on the backend and let the
+> MCP server inject them automatically, or prompt individual users to paste
+> their own cookies at runtime if you prefer not to store shared credentials.
+
+---
+
+With these pieces in place the ESPN Fantasy MCP backend runs as a fully managed
+service, reachable via HTTPS, and ready for OpenWebUI or any other MCP-capable
+client.

--- a/espn_api/mcp_server.py
+++ b/espn_api/mcp_server.py
@@ -22,6 +22,7 @@ credentials out of the transport layer.
 from __future__ import annotations
 
 import argparse
+import os
 from dataclasses import dataclass
 from functools import lru_cache
 import inspect
@@ -104,6 +105,23 @@ def _normalise_sport(sport: str) -> SportName:
     return aliases[sport_lower]  # type: ignore[return-value]
 
 
+_SWID_ENV_VARS = ("ESPN_MCP_SWID", "SWID")
+_ESPN_S2_ENV_VARS = ("ESPN_MCP_ESPN_S2", "ESPN_S2", "ESPN_S2_COOKIE")
+
+
+def _resolve_cookie(value: Optional[str], env_var_candidates: Tuple[str, ...]) -> Optional[str]:
+    """Return the provided value or fall back to the first populated env var."""
+
+    if value:
+        return value
+
+    for env_var in env_var_candidates:
+        candidate = os.environ.get(env_var)
+        if candidate:
+            return candidate
+    return None
+
+
 @lru_cache(maxsize=8)
 def _load_league_cached(key: LeagueKey) -> BaseLeague:
     """Load and cache a league instance for the provided parameters."""
@@ -125,7 +143,9 @@ def _load_league(
     espn_s2: Optional[str],
 ) -> BaseLeague:
     normalised = _normalise_sport(sport)
-    return _load_league_cached(LeagueKey(normalised, league_id, year, swid, espn_s2))
+    resolved_swid = _resolve_cookie(swid, _SWID_ENV_VARS)
+    resolved_espn_s2 = _resolve_cookie(espn_s2, _ESPN_S2_ENV_VARS)
+    return _load_league_cached(LeagueKey(normalised, league_id, year, resolved_swid, resolved_espn_s2))
 
 
 def _owner_to_dict(owner: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- clarify in the README that ESPN cookies should live on the backend instead of frontend build-time env vars
- expand the App Runner deployment guide with a note explaining why frontend env vars cannot keep the cookies private

## Testing
- ⚠️ Tests not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e268ff2aa88328b025bccc675217a2